### PR TITLE
feat: add a setFormatter static function to format log entries for development

### DIFF
--- a/src/Logger.test.ts
+++ b/src/Logger.test.ts
@@ -149,4 +149,20 @@ describe('Logger', () => {
       );
     }
   );
+
+  it('supports a custom formatter', async () => {
+    const logger = new Logger('context');
+    const mockLogFormatter = jest.fn(() => 'mock')
+    Logger.setFormatter(mockLogFormatter)
+    Logger.runWith(logger, () => {
+      Logger.info('hello')
+      expect(mockLogFormatter).toHaveBeenCalledWith(
+        expect.objectContaining({
+          time: '1970-01-01T00:00:00.000Z',
+          severity: 'INFO',
+          message: 'hello',
+        })
+      );
+    });
+  });
 });

--- a/src/Logger.test.ts
+++ b/src/Logger.test.ts
@@ -152,10 +152,10 @@ describe('Logger', () => {
 
   it('supports a custom formatter', async () => {
     const logger = new Logger('context');
-    const mockLogFormatter = jest.fn(() => 'mock')
-    Logger.setFormatter(mockLogFormatter)
+    const mockLogFormatter = jest.fn(() => 'mock');
+    Logger.setFormatter(mockLogFormatter);
     Logger.runWith(logger, () => {
-      Logger.info('hello')
+      Logger.info('hello');
       expect(mockLogFormatter).toHaveBeenCalledWith(
         expect.objectContaining({
           time: '1970-01-01T00:00:00.000Z',

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -4,16 +4,12 @@ import { randomUUID } from 'crypto';
 
 import { ILogger } from './ILogger';
 import { LogEntry } from './types/LogEntry';
+import { LogFormatter } from './types/LogFormatter';
 import { LogEntryMetadata } from './types/LogEntryMetadata';
 import { Severity } from './types/Severity';
 import { toJSON } from './utils/toJSON';
 
 const ERROR_EVENT = 'type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent';
-
-/**
- * A function type which can format a log entry to a string
- */
-type LogFormatter = (entry: LogEntry) => string
 
 export class Logger implements ILogger {
   /**
@@ -39,7 +35,7 @@ export class Logger implements ILogger {
   /**
    * A formatter function which takes a log entry and formats it to a string
    */
-  protected static formatter: LogFormatter = toJSON
+  protected static formatter: LogFormatter = toJSON;
 
   /**
    * Sets a global log level
@@ -67,8 +63,8 @@ export class Logger implements ILogger {
    * This can be useful for developers running the application locally and presenting logs in
    * a more developer-friendly form.
    */
-  public static setFormatter(formatter?: LogFormatter) {
-    this.formatter = formatter || toJSON
+  public static setFormatter(formatter: LogFormatter = toJSON) {
+    this.formatter = formatter;
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,5 @@ export * from './types/HttpRequest';
 export * from './types/LogEntry';
 export * from './types/LogEntryMetadata';
 export * from './types/LogEntryOperation';
+export * from './types/LogFormatter';
 export * from './types/Severity';

--- a/src/types/LogFormatter.ts
+++ b/src/types/LogFormatter.ts
@@ -1,0 +1,3 @@
+import { LogEntry } from './LogEntry';
+
+export type LogFormatter = (entry: LogEntry) => string;


### PR DESCRIPTION
This can be useful for developers running the application locally and presenting logs in a more developer-friendly form than the default stringified JSON.